### PR TITLE
update API prefix

### DIFF
--- a/chrome/js/115.js
+++ b/chrome/js/115.js
@@ -442,7 +442,7 @@ var pan_115 = function(cookies) {
             set_down_url:function(){
                 var self=this;
                 DownBridge={};
-                  $('<iframe>').attr('src', 'http://web.api.115.com/bridge_2.0.html?namespace=DownBridge&api=jQuery').css({
+                  $('<iframe>').attr('src', '//webapi.115.com/bridge_2.0.html?namespace=DownBridge&api=jQuery').css({
                     width: 0,
                     height: 0,
                     border: 0,
@@ -452,12 +452,12 @@ var pan_115 = function(cookies) {
                     top: '-99999px'
                   }).one('load',function(){
                     window.DownBridge.getFileUrl=function(pickcode,callback){
-                    this.jQuery.get('http://web.api.115.com/files/download?pickcode=' + pickcode, function (data) {
+                    this.jQuery.get('//webapi.115.com/files/download?pickcode=' + pickcode, function (data) {
                              callback(data);
                             }, 'json');                        
                     };
                     window.DownBridge.getFileList=function(cate_id,callback){
-                    this.jQuery.get('http://web.api.115.com/files?aid=1&limit=1000&show_dir=1&cid=' + cate_id, function (data) {
+                    this.jQuery.get('//webapi.115.com/files?aid=1&limit=1000&show_dir=1&cid=' + cate_id, function (data) {
                              callback(data);
                             }, 'json');                        
                     };

--- a/firefox/data/js/115.js
+++ b/firefox/data/js/115.js
@@ -442,7 +442,7 @@ var pan_115 = function(cookies) {
             set_down_url:function(){
                 var self=this;
                 DownBridge={};
-                  $('<iframe>').attr('src', 'http://web.api.115.com/bridge_2.0.html?namespace=DownBridge&api=jQuery').css({
+                  $('<iframe>').attr('src', '//webapi.115.com/bridge_2.0.html?namespace=DownBridge&api=jQuery').css({
                     width: 0,
                     height: 0,
                     border: 0,
@@ -452,12 +452,12 @@ var pan_115 = function(cookies) {
                     top: '-99999px'
                   }).one('load',function(){
                     window.DownBridge.getFileUrl=function(pickcode,callback){
-                    this.jQuery.get('http://web.api.115.com/files/download?pickcode=' + pickcode, function (data) {
+                    this.jQuery.get('//webapi.115.com/files/download?pickcode=' + pickcode, function (data) {
                              callback(data);
                             }, 'json');                        
                     };
                     window.DownBridge.getFileList=function(cate_id,callback){
-                    this.jQuery.get('http://web.api.115.com/files?aid=1&limit=1000&show_dir=1&cid=' + cate_id, function (data) {
+                    this.jQuery.get('//webapi.115.com/files?aid=1&limit=1000&show_dir=1&cid=' + cate_id, function (data) {
                              callback(data);
                             }, 'json');                        
                     };

--- a/safari/115.safariextension/script.js
+++ b/safari/115.safariextension/script.js
@@ -450,7 +450,7 @@ var pan_115 = function(cookies) {
             set_down_url:function(){
                 var self=this;
                 DownBridge={};
-                  $('<iframe>').attr('src', 'http://web.api.115.com/bridge_2.0.html?namespace=DownBridge&api=jQuery').css({
+                  $('<iframe>').attr('src', '//webapi.115.com/bridge_2.0.html?namespace=DownBridge&api=jQuery').css({
                     width: 0,
                     height: 0,
                     border: 0,
@@ -460,12 +460,12 @@ var pan_115 = function(cookies) {
                     top: '-99999px'
                   }).one('load',function(){
                     window.DownBridge.getFileUrl=function(pickcode,callback){
-                    this.jQuery.get('http://web.api.115.com/files/download?pickcode=' + pickcode, function (data) {
+                    this.jQuery.get('//webapi.115.com/files/download?pickcode=' + pickcode, function (data) {
                              callback(data);
                             }, 'json');                        
                     };
                     window.DownBridge.getFileList=function(cate_id,callback){
-                    this.jQuery.get('http://web.api.115.com/files?aid=1&limit=1000&show_dir=1&cid=' + cate_id, function (data) {
+                    this.jQuery.get('//webapi.115.com/files?aid=1&limit=1000&show_dir=1&cid=' + cate_id, function (data) {
                              callback(data);
                             }, 'json');                        
                     };


### PR DESCRIPTION
1. 现在115支持https了，原来的API都是走http协议的，这样会有mixed content的问题。
2. API的prefix没有办法统一，因为有跨域的时候“Access-Control-Allow-Origin”限制，只能根据不同的协议选择不同的域名进行访问。
3. Chrome extension测试过没有问题，但是FF跟Safari因为我不知道如何测试插件，所以只是修改了代码没有测试，如果有人测试过麻烦回复一下测试结果。
