### PR TITLE
fix checksum location

### DIFF
--- a/src/js/lib/core.js
+++ b/src/js/lib/core.js
@@ -190,7 +190,7 @@ class Core {
       const sha1Check = this.getConfigData('sha1Check')
       if (sha1Check) {
         aria2CmdLine += ` --checksum=sha-1=${file.sha1}`
-        aria2Line += ` checksum=sha-1=${file.sha1}`
+        aria2Line += `\n checksum=sha-1=${file.sha1}`
       }
       aria2CmdTxt.push(aria2CmdLine)
       aria2Txt.push(aria2Line)


### PR DESCRIPTION
现在checksum直接跟在out那一行后面了，应该先换行。

现在的输出类似这样

```
http://balabala/balabala
 header=User-Agent: UA
 header=Referer: referer
 header=Cookie: cookie
 out=/a/b/c/d checksum=sha-1=A3B1954474FC4360309AA1690942C4E6B92A11EE
```

正确的应该是这样
```
http://balabala/balabala
 header=User-Agent: UA
 header=Referer: referer
 header=Cookie: cookie
 out=/a/b/c/d
 checksum=sha-1=A3B1954474FC4360309AA1690942C4E6B92A11EE
```