### PR TITLE
Added an option to use browser's 'User-Agent' directly (instead of manually specify one)

### DIFF
--- a/src/css/setting.scss
+++ b/src/css/setting.scss
@@ -42,6 +42,14 @@
     &:focus {
       border-color: #5cb3fd;
     }
+
+    &:disabled {
+      opacity: 0.5;
+
+      &:hover {
+        cursor: not-allowed;
+      }
+    }
   }
 
   &-button {
@@ -90,6 +98,13 @@
 
     &.orange-o {
       color: #e15f00;
+    }
+
+    &.for {
+      &-checkbox {
+        font-size: 12px;
+        padding-left: 5px;
+      }
     }
   }
 

--- a/src/js/lib/core.js
+++ b/src/js/lib/core.js
@@ -49,7 +49,15 @@ class Core {
   }
   getHeader (type = 'RPC') {
     const headerOption = []
-    headerOption.push(`User-Agent: ${this.getConfigData('userAgent')}`)
+    const useBrowserUA = this.getConfigData('browserUserAgent');
+    var userAgent = this.getConfigData('userAgent');
+    if (useBrowserUA) {
+      const browserUA = navigator.userAgent;
+      if (browserUA && browserUA.length) {
+        userAgent = browserUA;
+      }
+    }
+    headerOption.push(`User-Agent: ${userAgent}`)
     headerOption.push(`Referer: ${this.getConfigData('referer')}`)
     headerOption.push(`Cookie: ${this.formatCookies()}`)
     const headers = this.getConfigData('headers')

--- a/src/js/lib/core.js
+++ b/src/js/lib/core.js
@@ -49,12 +49,12 @@ class Core {
   }
   getHeader (type = 'RPC') {
     const headerOption = []
-    const useBrowserUA = this.getConfigData('browserUserAgent');
-    var userAgent = this.getConfigData('userAgent');
+    const useBrowserUA = this.getConfigData('browserUserAgent')
+    var userAgent = this.getConfigData('userAgent')
     if (useBrowserUA) {
-      const browserUA = navigator.userAgent;
+      const browserUA = navigator.userAgent
       if (browserUA && browserUA.length) {
-        userAgent = browserUA;
+        userAgent = browserUA
       }
     }
     headerOption.push(`User-Agent: ${userAgent}`)

--- a/src/js/lib/store.js
+++ b/src/js/lib/store.js
@@ -13,7 +13,7 @@ class Store extends EventEmitter {
       interval: 300,
       downloadPath: '',
       userAgent: this.defaultUserAgent,
-      browserUserAgent: false,
+      browserUserAgent: true,
       referer: this.defaultReferer,
       headers: ''
     }

--- a/src/js/lib/store.js
+++ b/src/js/lib/store.js
@@ -13,6 +13,7 @@ class Store extends EventEmitter {
       interval: 300,
       downloadPath: '',
       userAgent: this.defaultUserAgent,
+      browserUserAgent: false,
       referer: this.defaultReferer,
       headers: ''
     }

--- a/src/js/lib/ui.js
+++ b/src/js/lib/ui.js
@@ -167,7 +167,7 @@ class UI {
                 <input class="setting-menu-input userAgent-s" spellcheck="false">
                 <label class="setting-menu-label"></label>
                 <input type="checkbox" class="setting-menu-checkbox browser-userAgent-s">
-                <label class="setting-menu-label">浏览器 UA</label>
+                <label class="setting-menu-label for-checkbox">使用浏览器 UA</label>
               </div>
             </div><!-- /.setting-menu-row -->
             <div class="setting-menu-row">

--- a/src/js/lib/ui.js
+++ b/src/js/lib/ui.js
@@ -257,7 +257,7 @@ class UI {
     testAria2.innerText = '测试连接，成功显示版本号'
   }
   updateSetting (configData) {
-    const { rpcList, configSync, sha1Check, interval, downloadPath, userAgent, browserUserAgent, referer, headers} = configData
+    const { rpcList, configSync, sha1Check, interval, downloadPath, userAgent, browserUserAgent, referer, headers } = configData
     // reset dom
     document.querySelectorAll('.rpc-s').forEach((rpc, index) => {
       if (index !== 0) {

--- a/src/js/lib/ui.js
+++ b/src/js/lib/ui.js
@@ -165,6 +165,9 @@ class UI {
               </div>
               <div class="setting-menu-value">
                 <input class="setting-menu-input userAgent-s" spellcheck="false">
+                <label class="setting-menu-label"></label>
+                <input type="checkbox" class="setting-menu-checkbox browser-userAgent-s">
+                <label class="setting-menu-label">浏览器 UA</label>
               </div>
             </div><!-- /.setting-menu-row -->
             <div class="setting-menu-row">
@@ -240,6 +243,12 @@ class UI {
     testAria2.addEventListener('click', () => {
       Core.getVersion(Store.getConfigData('rpcList')[0].url, testAria2)
     })
+
+    const userAgentField = document.querySelector('.userAgent-s')
+    const browserUACheckbox = document.querySelector('.browser-userAgent-s')
+    browserUACheckbox.addEventListener('change', () => {
+      userAgentField.disabled = browserUACheckbox.checked
+    })
   }
   resetSetting () {
     const message = document.querySelector('#message')
@@ -248,7 +257,7 @@ class UI {
     testAria2.innerText = '测试连接，成功显示版本号'
   }
   updateSetting (configData) {
-    const { rpcList, configSync, sha1Check, interval, downloadPath, userAgent, referer, headers } = configData
+    const { rpcList, configSync, sha1Check, interval, downloadPath, userAgent, browserUserAgent, referer, headers} = configData
     // reset dom
     document.querySelectorAll('.rpc-s').forEach((rpc, index) => {
       if (index !== 0) {
@@ -278,6 +287,8 @@ class UI {
     document.querySelector('.interval-s').value = interval
     document.querySelector('.downloadPath-s').value = downloadPath
     document.querySelector('.userAgent-s').value = userAgent
+    document.querySelector('.userAgent-s').disabled = browserUserAgent
+    document.querySelector('.browser-userAgent-s').checked = browserUserAgent
     document.querySelector('.referer-s').value = referer
     document.querySelector('.headers-s').value = headers
   }
@@ -296,6 +307,7 @@ class UI {
     const interval = document.querySelector('.interval-s').value
     const downloadPath = document.querySelector('.downloadPath-s').value
     const userAgent = document.querySelector('.userAgent-s').value
+    const browserUserAgent = document.querySelector('.browser-userAgent-s').checked
     const referer = document.querySelector('.referer-s').value
     const headers = document.querySelector('.headers-s').value
 
@@ -306,6 +318,7 @@ class UI {
       interval,
       downloadPath,
       userAgent,
+      browserUserAgent,
       referer,
       headers
     }


### PR DESCRIPTION
115.com now require downloader's User-Agent matches the user logged-on browser's. otherwise, the response will be `403 Forbidden`.

I added an "使用浏览器 UA" checkbox to the settings page beside User-Agent field, when checked, 115Exporter will use `navigator.userAgent` instead of the one filled in User-Agent field.