### PR TITLE
Add 'del' for devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "autoprefixer": "^9.1.5",
     "babelify": "^10.0.0",
     "browserify": "^16.2.3",
+    "del": "^3.0.0",
     "eslint-config-standard": "^12.0.0",
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-node": "^8.0.0",


### PR DESCRIPTION
Fix `Error: Cannot find module 'del'` when run `npm run build`