### PR TITLE
添加「小文件优先」模式，解决众多小文件下载失败问题 #251

### DIFF
--- a/src/js/home.js
+++ b/src/js/home.js
@@ -150,6 +150,7 @@ class Home extends Downloader {
           this.fileDownloadInfo.push({
             name: files[item.pickcode].path + item.file_name,
             link: item.file_url,
+            size: item.file_size,
             sha1: files[item.pickcode].sha1,
             cookies: item.cookies,
             pickcode: item.pickcode

--- a/src/js/lib/core.js
+++ b/src/js/lib/core.js
@@ -170,6 +170,12 @@ class Core {
   aria2RPCMode (rpcPath, fileDownloadInfo) {
     const { authStr, path, options } = this.parseURL(rpcPath)
     const ssl = this.getConfigData('ssl')
+    const small = this.getConfigData('small')
+
+    if (small) {
+      fileDownloadInfo.sort((a, b) => a.size - b.size)
+    }
+
     fileDownloadInfo.forEach((file) => {
       this.cookies = file.cookies
       if (ssl) {

--- a/src/js/lib/store.js
+++ b/src/js/lib/store.js
@@ -11,6 +11,7 @@ class Store extends EventEmitter {
       configSync: false,
       sha1Check: false,
       ssl: false,
+      small: false,
       interval: 300,
       downloadPath: '',
       userAgent: this.defaultUserAgent,

--- a/src/js/lib/ui.js
+++ b/src/js/lib/ui.js
@@ -191,6 +191,14 @@ class UI {
             </div><!-- /.setting-menu-row -->
             <div class="setting-menu-row">
               <div class="setting-menu-name">
+                <label class="setting-menu-label">小文件优先</label>
+              </div>
+              <div class="setting-menu-value">
+                <input type="checkbox" class="setting-menu-checkbox small-s">
+              </div>
+            </div><!-- /.setting-menu-row -->
+            <div class="setting-menu-row">
+              <div class="setting-menu-name">
                 <label class="setting-menu-label">强制SSL下载</label>
               </div>
               <div class="setting-menu-value">
@@ -315,7 +323,7 @@ class UI {
   }
 
   updateSetting (configData) {
-    const { rpcList, configSync, sha1Check, ssl, interval, downloadPath, userAgent, browserUserAgent, referer, headers } = configData
+    const { rpcList, configSync, sha1Check, ssl, small, interval, downloadPath, userAgent, browserUserAgent, referer, headers } = configData
     // reset dom
     document.querySelectorAll('.rpc-s').forEach((rpc, index) => {
       if (index !== 0) {
@@ -343,6 +351,7 @@ class UI {
     document.querySelector('.configSync-s').checked = configSync
     document.querySelector('.sha1Check-s').checked = sha1Check
     document.querySelector('.ssl-s').checked = ssl
+    document.querySelector('.small-s').checked = small
     document.querySelector('.interval-s').value = interval
     document.querySelector('.downloadPath-s').value = downloadPath
     document.querySelector('.userAgent-s').value = userAgent
@@ -366,6 +375,7 @@ class UI {
     const configSync = document.querySelector('.configSync-s').checked
     const sha1Check = document.querySelector('.sha1Check-s').checked
     const ssl = document.querySelector('.ssl-s').checked
+    const small = document.querySelector('.small-s').checked
     const interval = document.querySelector('.interval-s').value
     const downloadPath = document.querySelector('.downloadPath-s').value
     const userAgent = document.querySelector('.userAgent-s').value
@@ -378,6 +388,7 @@ class UI {
       configSync,
       sha1Check,
       ssl,
+      small,
       interval,
       downloadPath,
       userAgent,


### PR DESCRIPTION
据观察 115 不同文件大小的下载链接有效期似乎是不一样的，大文件的有效期会长一些，小文件就会很短。
这会导致大文件都下载完了，开始下载小文件时已经超过有效期，导致HTTP 500错误。解决 issues #251