### PR TITLE
fix URLSearchParams

### DIFF
--- a/src/js/lib/core.js
+++ b/src/js/lib/core.js
@@ -100,8 +100,9 @@ class Core {
     const paramsString = parseURL.hash.substr(1)
     const options = {}
     const searchParams = new URLSearchParams(paramsString)
-    for (const key of searchParams) {
-      options[key[0]] = key.length === 2 ? key[1] : 'enabled'
+    for (const searchParam of searchParams) {
+      const [option, value] = searchParam
+      options[option] = value.length ? value : 'enabled'
     }
     const path = parseURL.origin + parseURL.pathname
     return { authStr, path, options }


### PR DESCRIPTION
`key.length === 2` always return true

Run following code to test:

```js
var paramsString = "split=2&foo&bar="
var searchParams = new URLSearchParams(paramsString)

console.log(Object.fromEntries(searchParams.entries()))

console.log("--------------------")

for (const searchParam of searchParams) {
  console.log(searchParam.length == 2, typeof searchParam[1], searchParam[1].length)
}

// OUTPUT
//
// {split: "2", foo: "", bar: ""}
// --------------------
// true "string" 1
// true "string" 0
// true "string" 0
```