### PR TITLE
JSON-RPC PATH example

### DIFF
--- a/src/js/lib/ui.js
+++ b/src/js/lib/ui.js
@@ -166,10 +166,10 @@ class UI {
             </div>
             <div class="setting-menu-row rpc-s">
               <div class="setting-menu-name">
-                <input class="setting-menu-input name-s" spellcheck="false">
+                <input class="setting-menu-input name-s" spellcheck="false" placeholder="名称">
               </div>
               <div class="setting-menu-value">
-                <input class="setting-menu-input url-s" spellcheck="false">
+                <input class="setting-menu-input url-s" spellcheck="false" placeholder="示例: http://token:RPC密钥@127.0.0.1:6800/jsonrpc">
                 <a class="setting-menu-button" id="addRPC" href="javascript:void(0);">添加RPC地址</a>
               </div>
             </div><!-- /.setting-menu-row -->
@@ -282,10 +282,10 @@ class UI {
       const RPC = `
         <div class="setting-menu-row rpc-s">
           <div class="setting-menu-name">
-            <input class="setting-menu-input name-s" spellcheck="false">
+            <input class="setting-menu-input name-s" spellcheck="false" placeholder="名称">
           </div>
           <div class="setting-menu-value">
-            <input class="setting-menu-input url-s" spellcheck="false">
+            <input class="setting-menu-input url-s" spellcheck="false" placeholder="示例: http://token:RPC密钥@127.0.0.1:6800/jsonrpc">
           </div>
         </div><!-- /.setting-menu-row -->`
       Array.from(rpcDOMList).pop().insertAdjacentHTML('afterend', RPC)
@@ -339,10 +339,10 @@ class UI {
         const RPC = `
           <div class="setting-menu-row rpc-s">
             <div class="setting-menu-name">
-              <input class="setting-menu-input name-s" value="${rpc.name}" spellcheck="false">
+              <input class="setting-menu-input name-s" value="${rpc.name}" spellcheck="false" placeholder="名称">
             </div>
             <div class="setting-menu-value">
-              <input class="setting-menu-input url-s" value="${rpc.url}" spellcheck="false">
+              <input class="setting-menu-input url-s" value="${rpc.url}" spellcheck="false" placeholder="示例: http://token:RPC密钥@127.0.0.1:6800/jsonrpc">
             </div>
           </div><!-- /.setting-menu-row -->`
         Array.from(rpcDOMList).pop().insertAdjacentHTML('afterend', RPC)


### PR DESCRIPTION
在115相关的交流中观察到，有不少用户对于怎么填写这个 `RPC地址` 有一定的困惑。
诚然，进入项目在github的 `README` 里可以看到相关的说明，但如果能直接在设置表单里看到一个示例，相信对于解开这个困惑，是有一定的帮助的。